### PR TITLE
Fix node not resizing on workflow load

### DIFF
--- a/js/visual_image_picker.js
+++ b/js/visual_image_picker.js
@@ -228,6 +228,7 @@ app.registerExtension({
             if (!domWidget) return;
             container.style.height = "auto";
             const h = container.scrollHeight;
+            if (!h) return; // container not yet visible; animateFit will retry next frame
             container.style.height = h + "px";
             domWidget.computeSize = () => [node.size[0], h];
             node.setSize([node.size[0], node.computeSize()[1]]);
@@ -464,9 +465,9 @@ app.registerExtension({
 
         node.onConfigure = function() {
             setTimeout(() => {
-                update(); 
+                update();
                 if (pathWidget?.value && gridColl.classList.contains("open")) node.loadImages();
-                fit();
+                animateFit();
             }, 100);
         };
 
@@ -477,6 +478,6 @@ app.registerExtension({
         };
         
         node.size = [350, 180];
-        setTimeout(() => { update(); fit(); }, 100);
+        setTimeout(() => { update(); animateFit(); }, 100);
     }
 });


### PR DESCRIPTION
Here is a fix preventing Visual Image Picker node to keep its default size when loading a workflow from disk.

When loading a workflow, the DOM widget container may still be hidden during the initial `fit()` call, causing `scrollHeight` to return 0 and leaving the node at its default size. Guard `fit()` against a zero height and use `animateFit()` on configure/init so sizing is retried every frame for 420ms — long enough to outlast the first canvas render on any workflow.