### PR TITLE
Fix: restore DOM widget visibility and sizing for comfyui-frontend 1.43+

### DIFF
--- a/js/visual_folder_picker.js
+++ b/js/visual_folder_picker.js
@@ -74,8 +74,8 @@ app.registerExtension({
             container.style.height = "auto";
             const h = container.scrollHeight;
             if (!h) return;
-            container.style.setProperty("--comfy-widget-height", h + "px");
-            node.setSize([node.size[0], h]);
+            container.style.setProperty("--comfy-widget-height", (h + 12) + "px");
+            node.setSize([node.size[0], node.computeSize()[1]]);
             (app.canvas ?? app.graph)?.setDirty?.(true, true);
         };
 

--- a/js/visual_folder_picker.js
+++ b/js/visual_folder_picker.js
@@ -72,9 +72,7 @@ app.registerExtension({
         const fit = () => {
             if (!domWidget) return;
             container.style.height = "auto";
-            const h = container.scrollHeight;
-            if (!h) return;
-            container.style.setProperty("--comfy-widget-height", (h + 12) + "px");
+            if (!container.scrollHeight) return;
             node.setSize([node.size[0], node.computeSize()[1]]);
             (app.canvas ?? app.graph)?.setDirty?.(true, true);
         };
@@ -104,6 +102,7 @@ app.registerExtension({
         domWidget = node.addDOMWidget("folder_picker_ui", "div", container, {
             getValue: () => uiStateValue,
             setValue: (v) => { uiStateValue = v; },
+            getHeight: () => container.scrollHeight + 12,
         });
 
         node.loadFolders = async () => {

--- a/js/visual_folder_picker.js
+++ b/js/visual_folder_picker.js
@@ -39,7 +39,14 @@ app.registerExtension({
 
         const pathWidget = node.widgets.find(w => w.name === "folder_path");
         const folderWidget = node.widgets.find(w => w.name === "selected_folder");
-        let domWidget = node.widgets.find(w => w.name === "folder_picker_ui");
+
+        // Remove the placeholder STRING widget from Python — it's not a DOMWidgetImpl
+        // and won't be rendered by the Vue DomWidget component in 1.43+
+        const existingIdx = node.widgets.findIndex(w => w.name === "folder_picker_ui");
+        let uiStateValue = existingIdx >= 0 ? (node.widgets[existingIdx].value || "") : "";
+        if (existingIdx >= 0) node.widgets.splice(existingIdx, 1);
+
+        let domWidget = null;
 
         const gridView = $el("div.vfp-grid");
         const pathDisplay = $el("div.vfp-path-display", { textContent: pathWidget?.value || "" });
@@ -57,11 +64,9 @@ app.registerExtension({
         ]);
 
         const saveUiState = () => {
-            if (domWidget) {
-                domWidget.value = JSON.stringify({
-                    grid: gridColl.classList.contains("open")
-                });
-            }
+            uiStateValue = JSON.stringify({
+                grid: gridColl.classList.contains("open")
+            });
         };
 
         const fit = () => {
@@ -69,9 +74,9 @@ app.registerExtension({
             container.style.height = "auto";
             const h = container.scrollHeight;
             if (!h) return;
-            domWidget.computeSize = () => [node.size[0], h];
-            node.setSize([node.size[0], domWidget.computeSize()[1]]);
-            app.graph.setDirtyCanvas(true, true);
+            container.style.setProperty("--comfy-widget-height", h + "px");
+            node.setSize([node.size[0], h]);
+            (app.canvas ?? app.graph)?.setDirty?.(true, true);
         };
 
         const animateFit = (duration = 420) => {
@@ -96,13 +101,10 @@ app.registerExtension({
             signal: scrollController.signal 
         });
 
-        if (domWidget) {
-            domWidget.type = "div";
-            domWidget.element = container;
-            domWidget.draw = () => {};
-        } else {
-            domWidget = node.addDOMWidget("folder_picker_ui", "div", container);
-        }
+        domWidget = node.addDOMWidget("folder_picker_ui", "div", container, {
+            getValue: () => uiStateValue,
+            setValue: (v) => { uiStateValue = v; },
+        });
 
         node.loadFolders = async () => {
             if (!pathWidget) return;
@@ -167,9 +169,9 @@ app.registerExtension({
         node.onConfigure = function() {
             gridColl.style.transition = "none";
             setTimeout(() => {
-                if (domWidget && domWidget.value) {
+                if (uiStateValue) {
                     try {
-                        const state = JSON.parse(domWidget.value);
+                        const state = JSON.parse(uiStateValue);
                         gridColl.classList.toggle("open", !!state.grid);
                     } catch (e) {}
                 }

--- a/js/visual_image_picker.js
+++ b/js/visual_image_picker.js
@@ -243,8 +243,8 @@ app.registerExtension({
             container.style.height = "auto";
             const h = container.scrollHeight;
             if (!h) return;
-            container.style.setProperty("--comfy-widget-height", h + "px");
-            node.setSize([node.size[0], h]);
+            container.style.setProperty("--comfy-widget-height", (h + 12) + "px");
+            node.setSize([node.size[0], node.computeSize()[1]]);
             (app.canvas ?? app.graph)?.setDirty?.(true, true);
         };
 

--- a/js/visual_image_picker.js
+++ b/js/visual_image_picker.js
@@ -241,9 +241,7 @@ app.registerExtension({
 
         const fit = () => {
             container.style.height = "auto";
-            const h = container.scrollHeight;
-            if (!h) return;
-            container.style.setProperty("--comfy-widget-height", (h + 12) + "px");
+            if (!container.scrollHeight) return;
             node.setSize([node.size[0], node.computeSize()[1]]);
             (app.canvas ?? app.graph)?.setDirty?.(true, true);
         };
@@ -378,6 +376,7 @@ app.registerExtension({
         domWidget = node.addDOMWidget("image_picker_ui", "div", container, {
             getValue: () => uiStateValue,
             setValue: (v) => { uiStateValue = v; },
+            getHeight: () => container.scrollHeight + 12,
         });
 
         node.loadImages = async () => {

--- a/js/visual_image_picker.js
+++ b/js/visual_image_picker.js
@@ -63,7 +63,14 @@ app.registerExtension({
         const pathWidget = node.widgets.find(w => w.name === "folder_path");
         const imgWidget = node.widgets.find(w => w.name === "selected_image");
         const sortWidget = node.widgets.find(w => w.name === "sort_method");
-        let domWidget = node.widgets.find(w => w.name === "image_picker_ui");
+
+        // Remove the placeholder STRING widget from Python — it's not a DOMWidgetImpl
+        // and won't be rendered by the Vue DomWidget component in 1.43+
+        const existingIdx = node.widgets.findIndex(w => w.name === "image_picker_ui");
+        let uiStateValue = existingIdx >= 0 ? (node.widgets[existingIdx].value || "") : "";
+        if (existingIdx >= 0) node.widgets.splice(existingIdx, 1);
+
+        let domWidget = null;
 
         let multiSelectEnabled = false;
         const MOVE_THRESHOLD = 10;
@@ -219,12 +226,10 @@ app.registerExtension({
         const browseBar = $el("div.vip-bar-wrapper", [btnGrid, btnMulti]);
 
         const saveUiState = () => {
-            if (domWidget) {
-                domWidget.value = JSON.stringify({
-                    preview: previewColl.classList.contains("open"),
-                    grid: gridColl.classList.contains("open")
-                });
-            }
+            uiStateValue = JSON.stringify({
+                preview: previewColl.classList.contains("open"),
+                grid: gridColl.classList.contains("open")
+            });
         };
 
         let fitRafId;
@@ -238,9 +243,9 @@ app.registerExtension({
             container.style.height = "auto";
             const h = container.scrollHeight;
             if (!h) return;
-            domWidget.computeSize = () => [node.size[0], h];
-            node.setSize([node.size[0], domWidget.computeSize()[1]]);
-            app.graph.setDirtyCanvas(true, true);
+            container.style.setProperty("--comfy-widget-height", h + "px");
+            node.setSize([node.size[0], h]);
+            (app.canvas ?? app.graph)?.setDirty?.(true, true);
         };
 
         const animateFit = (duration = 420) => {
@@ -369,14 +374,11 @@ app.registerExtension({
         window.addEventListener("wheel", handleWheel, { capture: true, passive: false });
 
         const container = $el("div.vip-container", [btnPrev, previewColl, browseBar, gridColl]);
-        
-        if (domWidget) {
-            domWidget.type = "div"; 
-            domWidget.element = container;
-            domWidget.draw = () => {};
-        } else {
-            domWidget = node.addDOMWidget("image_picker_ui", "div", container);
-        }
+
+        domWidget = node.addDOMWidget("image_picker_ui", "div", container, {
+            getValue: () => uiStateValue,
+            setValue: (v) => { uiStateValue = v; },
+        });
 
         node.loadImages = async () => {
             const path = pathWidget?.value;
@@ -479,9 +481,9 @@ app.registerExtension({
             gridColl.style.transition = "none";
 
             setTimeout(() => {
-                if (domWidget && domWidget.value) {
+                if (uiStateValue) {
                     try {
-                        const state = JSON.parse(domWidget.value);
+                        const state = JSON.parse(uiStateValue);
                         previewColl.classList.toggle("open", !!state.preview);
                         gridColl.classList.toggle("open", !!state.grid);
                         btnGrid.querySelector("span:last-child").style.color = state.grid ? '#00b4ff' : '';


### PR DESCRIPTION
`comfyui-frontend-package` 1.43 changed how DOM widget elements are rendered: they are now positioned by a Vue component (`DomWidget`) that only displays widgets registered via  `addDOMWidget()` `widgetStore.registerWidget()`. The previous pattern of reusing the Python-declared `STRING` placeholder widget and manually setting `.element` on it bypassed this registration entirely, causing both nodes to render blank.

  Changes
  - Remove the Python-declared `STRING` placeholder widget before creating the DOM widget, then always call `node.addDOMWidget()` to ensure proper registration in the widget store
  - Store UI state (open/closed panels) in a closure variable backed by `getValue`/`setValue` options instead of directly on the widget
  - Replace `domWidget.computeSize` override (no longer called) with the `getHeight` option, which `computeLayoutSize()` checks first, more explicit and less fragile than the `--comfy-widget-height` CSS variable fallback
  - Use `node.setSize([node.size[0], node.computeSize()[1]])` so node height accounts for all widgets (title bar + standard widgets + DOM widget), while preserving user-resized width
  - Update canvas dirty call to `(app.canvas ?? app.graph)?.setDirty?.(true, true)` for forward compatibility

  Affected nodes: **Visual Image Picker**, **Visual Folder Picker**